### PR TITLE
Container Storage Functionality Bug Fix

### DIFF
--- a/src/main/java/net/pitan76/storagebox/StorageBoxItem.java
+++ b/src/main/java/net/pitan76/storagebox/StorageBoxItem.java
@@ -500,6 +500,7 @@ public class StorageBoxItem extends Item {
                         ItemStack stack = slot.getStack();
                         if (!stack.isEmpty()) continue;
                         ItemStack newStack = itemInBox.copy();
+                        if(!slot.canInsert(newStack)) continue;
                         int stackMax = itemInBox.getMaxCount();
                         // 64より大きい
                         if (count > stackMax) {


### PR DESCRIPTION
Fixed a bug that allowed items to be stored in slots where they normally couldn't be stored.(Fuel slot for the stove, result slot, etc.)

本来収納できないスロットにも収納できてしまう不具合を修正(かまどの燃料スロット、結果スロットなど)